### PR TITLE
BREAKING CHANGE -  change Disk.driver type to string

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -20,7 +20,7 @@ export interface Disk {
   /**
    * Determins which driver is to be used
    */
-  driver: DriverType,
+  driver: string | DriverType,
 }
 
 /**


### PR DESCRIPTION
## Description
<!--- Please describe your changes in detail -->
This change is necessary to allow 3rd party or experimental drivers to be registiered.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!-- Please reference the issue tracking number that this pull request relates to -->


<!-- Which ticket does this pull request close? -->
<!--- eg. "Closes #1" -->

### Checklist
<!--- Please check all the boxes that apply. --->
- [x] This change complies with the [**contributing**](https://daniel-samson.github.io/typefs/docs/contributing/join) guidelines.
- [x] I have provided automated tests to verify that these changes are correct.


